### PR TITLE
PluginsManager.loadModulesByClassNames method implementation

### DIFF
--- a/guice-bootstrap/src/main/java/com/magenta/guice/bootstrap/plugins/PluginsManager.java
+++ b/guice-bootstrap/src/main/java/com/magenta/guice/bootstrap/plugins/PluginsManager.java
@@ -45,6 +45,13 @@ public final class PluginsManager {
         }
     };
 
+    /**
+     * Loads plugins from path
+     * @param injector
+     * @param pluginsPath
+     * @param providedCL
+     * @return
+     */
     public static Injector loadPlugins(Injector injector, File pluginsPath, @Nullable URLClassLoader providedCL) {
         Collection<Module> modules = loadModules(pluginsPath, providedCL);
         for (Module module : modules) {
@@ -59,6 +66,12 @@ public final class PluginsManager {
         return injector;
     }
 
+    /**
+     * Loads modules from path
+     * @param pluginsPath
+     * @param providedCL
+     * @return collection of loaded modules
+     */
     public static Collection<Module> loadModules(File pluginsPath, @Nullable URLClassLoader providedCL) {
         checkPath(pluginsPath);
         URL[] jars = scanJars(pluginsPath);
@@ -90,6 +103,11 @@ public final class PluginsManager {
         return modules;
     }
 
+    /**
+     * Adds JARs to provided class loader
+     * @param providedCL
+     * @param jars
+     */
     private static void addJarsToClassLoader(URLClassLoader providedCL, URL[] jars) {
         Class urlClass = URLClassLoader.class;
         Method method;
@@ -110,6 +128,11 @@ public final class PluginsManager {
         }
     }
 
+    /**
+     * Converts JAR files in path to array of URLs
+     * @param pluginsPath
+     * @return array of URLs
+     */
     private static URL[] scanJars(File pluginsPath) {
         //prepare jars URL
         File[] jarFiles = pluginsPath.listFiles(jarFilter);
@@ -126,6 +149,11 @@ public final class PluginsManager {
         return urls;
     }
 
+    /**
+     * Scans a directory for plugins
+     * @param pluginsPath
+     * @return collection of found plugins
+     */
     static Collection<Plugin> scan(File pluginsPath) {
         File[] jarFiles = pluginsPath.listFiles(jarFilter);
         Collection<Plugin> plugins = new HashSet<Plugin>();
@@ -150,6 +178,10 @@ public final class PluginsManager {
         return plugins;
     }
 
+    /**
+     * Checks if path exists
+     * @param path
+     */
     static void checkPath(File path) {
         if (!path.exists()) {
             throw new IllegalArgumentException(String.format("Path '%s' is not exists", path));

--- a/guice-bootstrap/src/test/java/com/magenta/guice/plugins/FooModuleImpl.java
+++ b/guice-bootstrap/src/test/java/com/magenta/guice/plugins/FooModuleImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2008-2015 Maxifier Ltd. All Rights Reserved.
+ */
+package com.magenta.guice.plugins;
+
+import com.google.inject.AbstractModule;
+
+/**
+ * FooModuleImpl
+ *
+ * @author Denis Kokin (denis.kokin@maxifier.com) (2015-05-29 11:39)
+ */
+public class FooModuleImpl extends AbstractModule implements Foo {
+    @Override
+    public String getName() {
+        return "Guice";
+    }
+
+    @Override
+    protected void configure() {
+
+    }
+}

--- a/guice-bootstrap/src/test/java/com/magenta/guice/plugins/PluginsManagerTest.java
+++ b/guice-bootstrap/src/test/java/com/magenta/guice/plugins/PluginsManagerTest.java
@@ -42,4 +42,13 @@ public class PluginsManagerTest {
         Injector inj = Guice.createInjector(new MainModule());
         PluginsManager.loadPlugins(inj, new File("src/test/jars"), systemClassLoader);
     }
+
+    @Test
+    public void testPluginManagerWithLoadingByClassNames() throws Exception {
+        Collection<Module> modules = PluginsManager.loadModulesByClassNames(
+                new File("target/test-classes/"),
+                new String[]{"com.magenta.guice.plugins.FooModuleImpl"}
+        );
+        assertEquals(modules.size(), 1);
+    }
 }


### PR DESCRIPTION
`loadModulesByClassNames` method added to PluginsManager to support loading modules from specific folder by their class name.