### PR TITLE
Refactor PropertyReader to support UTF-8 property encoding

### DIFF
--- a/guice-property/src/main/java/com/maxifier/guice/property/PropertyModule.java
+++ b/guice-property/src/main/java/com/maxifier/guice/property/PropertyModule.java
@@ -61,20 +61,31 @@ public class PropertyModule implements Module {
     }
 
     /**
-     * Load properties from resource {@code module.getClass().getProperty() + ".properties"}
+     * Load properties from resource {@code module.getClass().properties} using UTF-8 encoding.
+     * @see #loadFrom(Class)
      */
     public static PropertyModule loadFrom(Module module) {
         return loadFrom(module.getClass());
     }
 
     /**
-     * Read properties from classpath resource {@code moduleClass.getProperty() + ".properties"}
+     * Read properties from classpath resource {@code moduleClass.properties} using UTF-8 encoding.
+     * <p>Property lookup sequence:</p>
+     * <ol>
+     *     <li>${moduleClass.getSimpleName()}.properties</li>
+     *     <li>${modulePackage.getName()}/${moduleClass.getSimpleName()}.properties</li>
+     *     <li>${moduleClass.getName()}.properties</li>
+     * </ol>
      */
     public static PropertyModule loadFrom(Class<? extends Module> moduleClass) {
+        ClassLoader classLoader = moduleClass.getClassLoader();
         String resourceName = moduleClass.getSimpleName() + ".properties";
-        InputStream inputStream = moduleClass.getResourceAsStream(resourceName);
-        if (inputStream == null) { // try w/o package name
-            inputStream = moduleClass.getResourceAsStream("/" + resourceName);
+        InputStream inputStream = classLoader.getResourceAsStream(resourceName);
+        if (inputStream == null) { // try with package
+            inputStream = moduleClass.getResourceAsStream(resourceName);
+        }
+        if (inputStream == null) { // try with full name
+            inputStream = classLoader.getResourceAsStream(moduleClass.getName() + ".properties");
         }
         if (inputStream == null) {
             throw new IllegalArgumentException("Can't load resource " + resourceName);
@@ -118,7 +129,7 @@ public class PropertyModule implements Module {
     }
 
     /**
-     * Reads properties from provided {@link InputStream} using ISO8859_1 encoding
+     * Reads properties from provided {@link InputStream} using UTF-8 encoding
      */
     public static PropertyModule loadFrom(InputStream inputStream) {
         try {
@@ -205,7 +216,7 @@ public class PropertyModule implements Module {
     }
 
     /**
-     * Reads properties from input stream using ISO8859_1 encoding.
+     * Reads properties from input stream using UTF-8 encoding.
      * <p>Data format is similar to original {@link Properties#load(InputStream)} format.</p>
      *
      * @param inputStream the input stream
@@ -231,7 +242,7 @@ public class PropertyModule implements Module {
         while (!reader.isEof()) {
             String comment = reader.readComment();
             String key = reader.readKey();
-            if (key != null) {
+            if (!key.isEmpty()) {
                 String value = reader.readValue();
                 properties.add(new PropertyDefinition(key, nullToEmpty(value), nullToEmpty(comment)));
             }

--- a/guice-property/src/main/java/com/maxifier/guice/property/PropertyModule.java
+++ b/guice-property/src/main/java/com/maxifier/guice/property/PropertyModule.java
@@ -40,6 +40,7 @@ import static com.maxifier.guice.property.converter.ArrayTypeConverter.*;
 @ParametersAreNonnullByDefault
 public class PropertyModule implements Module {
     private final ImmutableList<PropertyDefinition> properties;
+    private final String moduleName = UUID.randomUUID().toString();
     private final String source;
     private boolean bindConverters;
 
@@ -264,7 +265,7 @@ public class PropertyModule implements Module {
         binder = binder.skipSources(PropertyModule.class);
 
         // Bind module itself for later collection of properties
-        binder.bind(PropertyModule.class).annotatedWith(property(UUID.randomUUID().toString())).toInstance(this);
+        binder.bind(PropertyModule.class).annotatedWith(property(moduleName)).toInstance(this);
 
         for (PropertyDefinition prop : properties) {
             binder.bindConstant().annotatedWith(property(prop.getName())).to(prop.getValue());

--- a/guice-property/src/main/java/com/maxifier/guice/property/PropertyReader.java
+++ b/guice-property/src/main/java/com/maxifier/guice/property/PropertyReader.java
@@ -3,6 +3,7 @@
  */
 package com.maxifier.guice.property;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -32,14 +33,20 @@ import java.io.Reader;
  * @author Konstantin Lyamshin (2015-11-24 14:13)
  */
 class PropertyReader {
-    final StringBuilder res = new StringBuilder(1024);
-    final InputStream inputStream;
-    final byte[] bytes;
-    final Reader reader;
-    final char[] chars;
-    int len;
-    int pos;
+    private static final int REPLACEMENT_CHAR = '\uFFFD';
 
+    private final StringBuilder res = new StringBuilder(1024);
+    private final InputStream inputStream;
+    private final byte[] bytes;
+    private final Reader reader;
+    private final char[] chars;
+    private int len; // buffer len
+    private int pos; // buffer pos
+    private int c; // fetched char
+
+    /**
+     * Read properties from character stream
+     */
     PropertyReader(Reader reader) throws IOException {
         this.inputStream = null;
         this.bytes = null;
@@ -47,10 +54,12 @@ class PropertyReader {
         this.reader = reader;
         this.chars = new char[8192];
 
-        this.len = reader.read(chars);
-        this.pos = 0;
+        this.c = nextChar();
     }
 
+    /**
+     * Read properties from byte stream (imply UTF-8 encoding)
+     */
     PropertyReader(InputStream inputStream) throws IOException {
         this.inputStream = inputStream;
         this.bytes = new byte[8192];
@@ -58,42 +67,143 @@ class PropertyReader {
         this.reader = null;
         this.chars = null;
 
-        this.len = inputStream.read(bytes);
-        this.pos = 0;
+        this.c = nextByte();
     }
 
-    boolean isEof() {
-        return len <= 0;
-    }
+    private boolean hasNext() throws IOException {
+        if (len < 0) {
+            return true;
+        }
+        if (pos < len) {
+            return false;
+        }
 
-    private char next() throws IOException {
-        if (++pos >= len) {
-            pos = 0;
-            if (len <= 0) { // eof on previous step
-                return '\0';
-            }
+        pos = 0;
+        do {
             len = inputStream != null
                 ? inputStream.read(bytes)
                 : reader.read(chars);
-            if (len <= 0) { // eof reached
-                return '\0';
-            }
+        } while (len == 0);
+
+        return len < 0;
+    }
+
+    int peek() {
+        return c;
+    }
+
+    boolean next() throws IOException {
+        c = inputStream != null? nextByte(): nextChar();
+        return c != -1;
+    }
+
+    /**
+     * Read next code point from stream using UTF-8 encoding
+     */
+    private int nextByte() throws IOException {
+        if (hasNext()) {
+            return -1;
+        }
+        byte b1 = bytes[pos++];
+        if ((b1 & 0x80) == 0) { // single byte
+            return checkCodePoint(b1 & 0x7F);
         }
 
-        return inputStream != null
-            ? (char) (0xff & bytes[pos]) // equivalent to calling a ISO8859-1 decoder
-            : chars[pos];
+        if (hasNext()) {
+            return REPLACEMENT_CHAR;
+        }
+        byte b2 = bytes[pos++];
+        if ((b2 & 0xC0) != 0x80) {
+            pos--; // bring back unexpected byte
+            return REPLACEMENT_CHAR;
+        }
+        if ((b1 & 0xE0) == 0xC0) { // two bytes
+            return checkCodePoint((b1 & 0x1F) << 6 | (b2 & 0x3F));
+        }
+
+        if (hasNext()) {
+            return REPLACEMENT_CHAR;
+        }
+        byte b3 = bytes[pos++];
+        if ((b3 & 0xC0) != 0x80) {
+            pos--; // bring back unexpected byte
+            return REPLACEMENT_CHAR;
+        }
+        if ((b1 & 0xF0) == 0xE0) { // three bytes
+            return checkCodePoint((b1 & 0x0F) << 12 | (b2 & 0x3F) << 6 | (b3 & 0x3F));
+        }
+
+        if (hasNext()) {
+            return REPLACEMENT_CHAR;
+        }
+        byte b4 = bytes[pos++];
+        if ((b4 & 0xC0) != 0x80) {
+            pos--; // bring back unexpected byte
+            return REPLACEMENT_CHAR;
+        }
+        if ((b1 & 0xF8) == 0xF0) { // four bytes
+            return checkCodePoint((b1 & 0x07) << 18 | (b2 & 0x3F) << 12 | (b3 & 0x3F) << 6 | (b4 & 0x3F));
+        }
+
+        return REPLACEMENT_CHAR;
     }
 
-    private char peek() throws IOException {
-        pos--; // little hack :)
-        return next();
+    private static int checkCodePoint(int cp) {
+        return Character.isValidCodePoint(cp)? cp: REPLACEMENT_CHAR;
     }
 
-    private char unescapeUnicode() throws IOException {
+    private int nextChar() throws IOException {
+        if (hasNext()) {
+            return -1;
+        }
+        char c1 = chars[pos++];
+        if (!Character.isHighSurrogate(c1)) { // BMP char
+            return checkCodePoint(c1);
+        }
+
+        if (hasNext()) {
+            return REPLACEMENT_CHAR;
+        }
+        char c2 = chars[pos++];
+        if (!Character.isLowSurrogate(c2)) {
+            pos--; // bring back unexpected char
+            return REPLACEMENT_CHAR;
+        }
+
+        return Character.toCodePoint(c1, c2);
+    }
+
+    private boolean unescape() throws IOException {
+        next(); // skip slash
+        switch (c) {
+            case 'u': unescapeUnicode(); break;
+            case 't': c = '\t'; break;
+            case 'f': c = '\f'; break;
+            case 'r': c = '\r'; break;
+            case 'n': c = '\n'; break;
+
+            case '\r': // multi-line property value
+                next();
+
+            case '\n':
+                if (c == '\n') {
+                    next(); // skip CRLF sequence
+                }
+                while (isWhitespace() && next()) {
+                    // trim white spaces
+                }
+                return true;
+
+            case -1: // skip slash on EOF
+                return true;
+        }
+        return false; // do further processing
+    }
+
+    private void unescapeUnicode() throws IOException {
         int value = 0;
         for (int i = 0; i < 4; i++) {
-            char c = next();
+            next();
             switch (c) {
                 case '0': case '1': case '2': case '3': case '4':
                 case '5': case '6': case '7': case '8': case '9':
@@ -112,139 +222,108 @@ class PropertyReader {
                     throw new IllegalArgumentException("Malformed \\uxxxx encoding.");
             }
         }
-        return (char) value;
+        this.c = value;
     }
 
-    private char unescape(char c) throws IOException {
-        switch (c) {
-            case 'u': c = unescapeUnicode(); break;
-            case 't': c = '\t'; break;
-            case 'f': c = '\f'; break;
-            case 'r': c = '\r'; break;
-            case 'n': c = '\n'; break;
-        }
-        return c;
+    boolean isEof() {
+        return c == -1;
     }
 
-    static boolean isWhitespace(char c) {
+    boolean isWhitespace() {
         return c == ' ' || c == '\t' || c == '\f';
     }
 
-    static boolean isNL(char c) {
+    boolean isNL() {
         return c == '\n' || c == '\r';
     }
 
-    static boolean isWhitespaceOrNL(char c) {
-        return isWhitespace(c) || isNL(c);
+    boolean isWhitespaceOrNL() {
+        return isWhitespace() || isNL();
     }
 
-    static boolean isComment(char c) {
+    boolean isComment() {
         return c == '#' || c == '!';
     }
 
-    static boolean isDelimiter(char c) {
+    boolean isDelimiter() {
         return c == ':' || c == '=';
     }
 
+    @Nonnull
     String readComment() throws IOException {
-        boolean hasComment = false;
         res.setLength(0);
 
-        char c = peek();
-        while (!isEof()) { // loop on comment lines
-            while (isWhitespaceOrNL(c)) {
-                c = next(); // skip whitespaces and empty lines
-            }
+        while (isWhitespaceOrNL() && next()) {
+            // skip whitespaces and empty lines
+        }
 
-            if (!isComment(c)) {
-                break; // non comment line
-            }
-
-            hasComment = true;
-            c = next(); // skip comment mark
-            while (!isEof() && !isNL(c)) { // loop on comment chars
+        while (!isEof() && isComment()) { // loop on comment lines
+            next(); // skip comment char
+            while (!isEof() && !isNL()) { // loop on comment chars
                 if (c == '\\') {
-                    c = next(); // skip slash
-                    if (c == 'u') {
-                        c = unescapeUnicode();
-                    } else {
-                        res.append('\\'); // don't process escapes in comments
+                    next();
+                    switch (c) {
+                        case 'u': unescapeUnicode(); break;
+                        case '\r': // don't process NL and EOF escape
+                        case '\n':
+                        case -1: res.append('\\'); continue;
+                        default: res.append('\\'); // don't process escapes in comments
                     }
-                    continue;
                 }
-                res.append(c);
-                c = next();
+                res.appendCodePoint(c);
+                next();
             }
+
+            while (isWhitespaceOrNL() && next()) {
+                // skip whitespaces and empty lines
+            }
+
             res.append('\n'); // normalize new line char
         }
 
-        return hasComment? res.toString(): null;
+        return res.toString();
     }
 
+    @Nonnull
     String readKey() throws IOException {
         res.setLength(0);
 
-        char c = peek();
-        while (isWhitespaceOrNL(c)) {
-            c = next(); // skip whitespaces and empty lines
+        while (isWhitespaceOrNL() && next()) {
+            // skip whitespaces and empty lines
         }
 
-        if (isEof()) {
-            return null; // nothing read
-        }
-
-        if (isComment(c)) {
-            return null; // comment line
-        }
-
-        while (!isEof() && !isDelimiter(c) && !isWhitespaceOrNL(c)) {
-            if (c == '\\') {
-                c = next(); // skip slash
-                if (isEof()) {
-                    break;
-                }
-                res.append(unescape(c));
-                c = next();
+        while (!isEof() && !isDelimiter() && !isWhitespaceOrNL()) {
+            if (c == '\\' && unescape()) {
                 continue;
             }
+            res.appendCodePoint(c);
+            next();
+        }
 
-            res.append(c);
-            c = next();
+        while (isWhitespace() || isDelimiter()) {
+            next(); // skip delimiters, don't skip NL to process empty value correctly
         }
 
         return res.toString();
     }
 
+    @Nonnull
     String readValue() throws IOException {
         res.setLength(0);
 
-        char c = peek();
-        while (isWhitespace(c) || isDelimiter(c)) {
-            c = next(); // skip delimiters
-        }
-
-        while (!isEof() && !isNL(c)) {
-            if (c == '\\') {
-                c = next(); // skip slash
-                if (isEof()) {
-                    break;
-                }
-                if (isNL(c)) { // multi-line property value
-                    while (isWhitespaceOrNL(c)) { // skip white spaces and empty lines
-                        c = next();
-                    }
-                    continue;
-                }
-
-                res.append(unescape(c));
-                c = next();
+        while (!isEof() && !isNL()) {
+            if (c == '\\' && unescape()) {
                 continue;
             }
+            res.appendCodePoint(c);
+            next();
+        }
 
-            res.append(c);
-            c = next();
+        while (isNL() && next()) {
+            // skip delimiters
         }
 
         return res.toString();
     }
+
 }

--- a/guice-property/src/test/java/com/maxifier/guice/property/PropertyAnnotationParserTest.java
+++ b/guice-property/src/test/java/com/maxifier/guice/property/PropertyAnnotationParserTest.java
@@ -25,11 +25,12 @@ public class PropertyAnnotationParserTest extends org.testng.Assert {
             { "line1", "=line1" },
             { "\tline1\f\n", "=line1" },
             { "@attr", "@attr="},
-            { "line1\n\nline2\n", "=line1\n\nline2" },
+            { "line1\n\nline2\n", "=line1\nline2" },
             { "line1\n\n@attr val\n", "=line1,@attr=val" },
             { "line1\n\n@attr\n@bttr", "=line1,@attr=,@bttr=" },
             { "line1\n\n@attr val\n@bttr vbl", "=line1,@attr=val,@bttr=vbl" },
-            { " @attr1 val1\n\t@attr2\tval2\r\t val3\t\n", "@attr1=val1,@attr2=val2\r\t val3" },
+            { " @attr1 val1\n\t@attr2\tval2\r\t val3\t\n", "@attr1=val1,@attr2=val2\nval3" },
+            { "# comment1\n value \n @attr\n # comment 3 \n aval", "=# comment1\nvalue,@attr=# comment 3\naval" } // bad thing: comments in comments
         };
     }
 
@@ -47,7 +48,7 @@ public class PropertyAnnotationParserTest extends org.testng.Assert {
     public void testGetPropertyAnnotation() throws Exception {
         String[] text = {
             " comment",
-            " @multiline true",
+            " @multiline true ",
             " check",
             " @type text"
         };
@@ -55,7 +56,7 @@ public class PropertyAnnotationParserTest extends org.testng.Assert {
         PropertyDefinition definition = new PropertyDefinition("k", "v", Joiner.on('\n').join(text));
 
         assertEquals(getPropertyAnnotation(definition, ""), "comment");
-        assertEquals(getPropertyAnnotation(definition, "@multiline"), "true\n check");
+        assertEquals(getPropertyAnnotation(definition, "@multiline"), "true\ncheck");
         assertEquals(getPropertyAnnotation(definition, "@type"), "text");
         assertEquals(getPropertyAnnotation(definition, "@none"), null);
     }

--- a/guice-property/src/test/java/com/maxifier/guice/property/PropertyModuleTest.java
+++ b/guice-property/src/test/java/com/maxifier/guice/property/PropertyModuleTest.java
@@ -55,6 +55,14 @@ public class PropertyModuleTest extends org.testng.Assert {
     }
 
     @Test
+    public void testLoadFromModuleClassFullName() throws Exception {
+        PropertyModule module = PropertyModule.loadFrom(TestSampleModule3.class);
+
+        ImmutableList<PropertyDefinition> properties = module.getProperties();
+        assertPropertiesList(properties, "furrr");
+    }
+
+    @Test
     public void testLoadFromCustomResource() throws Exception {
         PropertyModule module = PropertyModule.loadFrom("custom.properties");
 
@@ -149,64 +157,67 @@ public class PropertyModuleTest extends org.testng.Assert {
         assertEquals(config.abaz, new boolean[] {true, true, false});
     }
 
-    static class TestSampleModule extends AbstractModule {
-        @Override
-        protected void configure() {
-            install(PropertyModule.loadFrom(this).withConverters());
-            bind(TestSampleConfig.class);
-        }
-    }
+}
 
-    static abstract class TestSampleModule2 implements Module {
-    }
-
-    static class TestSampleConfigSimple {
-        @Inject
-        @Property("foo")
-        String foo;
-
-        @Inject
-        @Property("bar")
-        int bar;
-
-        @Inject
-        @Property("bar")
-        String sbar;
-
-        @Inject
-        @Property("baz")
-        boolean baz;
-    }
-
-    static class TestSampleConfig {
-        @Inject
-        @Property("foo")
-        String foo;
-
-        @Inject
-        @Property("bar")
-        int bar;
-
-        @Inject
-        @Property("bar")
-        String sbar;
-
-        @Inject
-        @Property("baz")
-        boolean baz;
-
-        @Inject
-        @Property("foo-array")
-        String[] afoo;
-
-        @Inject
-        @Property("bar-array")
-        int[] abar;
-
-        @Inject
-        @Property("baz-array")
-        boolean[] abaz;
+class TestSampleModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        install(PropertyModule.loadFrom(this).withConverters());
+        bind(TestSampleConfig.class);
     }
 }
 
+abstract class TestSampleModule2 implements Module {
+}
+
+abstract class TestSampleModule3 implements Module {
+}
+
+class TestSampleConfigSimple {
+    @Inject
+    @Property("foo")
+    String foo;
+
+    @Inject
+    @Property("bar")
+    int bar;
+
+    @Inject
+    @Property("bar")
+    String sbar;
+
+    @Inject
+    @Property("baz")
+    boolean baz;
+}
+
+class TestSampleConfig {
+    @Inject
+    @Property("foo")
+    String foo;
+
+    @Inject
+    @Property("bar")
+    int bar;
+
+    @Inject
+    @Property("bar")
+    String sbar;
+
+    @Inject
+    @Property("baz")
+    boolean baz;
+
+    @Inject
+    @Property("foo-array")
+    String[] afoo;
+
+    @Inject
+    @Property("bar-array")
+    int[] abar;
+
+    @Inject
+    @Property("baz-array")
+    boolean[] abaz;
+}
 

--- a/guice-property/src/test/resources/com.maxifier.guice.property.TestSampleModule3.properties
+++ b/guice-property/src/test/resources/com.maxifier.guice.property.TestSampleModule3.properties
@@ -1,0 +1,4 @@
+# Default properties for TestSampleModule3
+
+furrr=foozzzz
+


### PR DESCRIPTION
Refactor PropertyReader to support UTF-8 property encoding

-- Refactor PropertyReader, split peek() and next(), fix EOL escaping
-- Use PropertyReader in PropertyAnnotationParser
-- Add full class name lookup in PropertyModule.loadFrom()
-- Use constant name for PropertyModule binding 